### PR TITLE
delegate configuration observing to base linter

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -2,7 +2,9 @@ path = require 'path'
 
 module.exports =
   config:
-    goExecutablePath:
+    executablePath:
+      title: 'GO Executable Path'
+      description: 'Path where govet bin located'
       type: 'string'
       default: ''
 

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -4,7 +4,7 @@ module.exports =
   config:
     executablePath:
       title: 'GO Executable Path'
-      description: 'Path where govet bin located'
+      description: 'The path where govet is located'
       type: 'string'
       default: ''
 

--- a/lib/linter-govet.coffee
+++ b/lib/linter-govet.coffee
@@ -7,8 +7,6 @@ class LinterGovet extends Linter
 
   cmd: ['go', 'tool', 'vet', '-v']
 
-  executablePath: null
-
   errorStream: 'stderr'
 
   defaultLevel: 'warning'
@@ -17,15 +15,6 @@ class LinterGovet extends Linter
 
   regex: '.+?:(?<line>\\d+):((?<col>\\d+):)? (?<message>.+)'
 
-  constructor: (editor) ->
-    super(editor)
-
-    @subscriptions = new CompositeDisposable
-
-    @subscriptions.add atom.config.observe 'linter-govet.goExecutablePath', (path) =>
-      @executablePath = atom.config.get 'linter-govet.goExecutablePath'
-
-  destroy: ->
-    @subscriptions.dispose()
+  options: ['executablePath']
 
 module.exports = LinterGovet


### PR DESCRIPTION
since 0.12.3 released, it's better to delegate configuration observing to base linter. see https://github.com/AtomLinter/Linter/pull/531